### PR TITLE
Fix issues w/ Cstrings that aren't null-terminated

### DIFF
--- a/libsignal-protocol-swift.xcodeproj/project.pbxproj
+++ b/libsignal-protocol-swift.xcodeproj/project.pbxproj
@@ -2740,7 +2740,7 @@
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = RU829Y5CY7;
+				DEVELOPMENT_TEAM = H8WR4M6QQ4;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -2756,7 +2756,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "itftwbr.libsignal-protocol-swift";
+				PRODUCT_BUNDLE_IDENTIFIER = "christophhagen.libsignal-protocol-swift";
 				PRODUCT_NAME = SignalProtocol;
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
@@ -2770,7 +2770,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = RU829Y5CY7;
+				DEVELOPMENT_TEAM = H8WR4M6QQ4;
 				INFOPLIST_FILE = "libsignal-protocol-swiftTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2788,9 +2788,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = RU829Y5CY7;
+				DEVELOPMENT_TEAM = H8WR4M6QQ4;
 				INFOPLIST_FILE = "libsignal-protocol-swiftTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/libsignal-protocol-swift.xcodeproj/project.pbxproj
+++ b/libsignal-protocol-swift.xcodeproj/project.pbxproj
@@ -2708,7 +2708,7 @@
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = RU829Y5CY7;
+				DEVELOPMENT_TEAM = H8WR4M6QQ4;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -2724,7 +2724,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "itftwbr.libsignal-protocol-swift";
+				PRODUCT_BUNDLE_IDENTIFIER = "christophhagen.libsignal-protocol-swift";
 				PRODUCT_NAME = SignalProtocol;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -2768,7 +2768,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = H8WR4M6QQ4;
 				INFOPLIST_FILE = "libsignal-protocol-swiftTests/Info.plist";
@@ -2807,7 +2806,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
@@ -2842,7 +2841,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;

--- a/libsignal-protocol-swift.xcodeproj/project.pbxproj
+++ b/libsignal-protocol-swift.xcodeproj/project.pbxproj
@@ -1899,15 +1899,16 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0930;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1130;
 				ORGANIZATIONNAME = User;
 				TargetAttributes = {
 					CE1F0C34203467B3003F1C04 = {
 						CreatedOnToolsVersion = 9.3;
-						LastSwiftMigration = 0930;
+						LastSwiftMigration = 1130;
 					};
 					CE1F0C3D203467B3003F1C04 = {
 						CreatedOnToolsVersion = 9.3;
+						LastSwiftMigration = 1130;
 					};
 					CE1F0C5320346830003F1C04 = {
 						CreatedOnToolsVersion = 9.3;
@@ -2691,6 +2692,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 4.2;
 				VALIDATE_PRODUCT = YES;
@@ -2706,7 +2708,7 @@
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = H8WR4M6QQ4;
+				DEVELOPMENT_TEAM = RU829Y5CY7;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -2722,11 +2724,11 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "christophhagen.libsignal-protocol-swift";
+				PRODUCT_BUNDLE_IDENTIFIER = "itftwbr.libsignal-protocol-swift";
 				PRODUCT_NAME = SignalProtocol;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -2738,7 +2740,7 @@
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = H8WR4M6QQ4;
+				DEVELOPMENT_TEAM = RU829Y5CY7;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -2754,10 +2756,10 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "christophhagen.libsignal-protocol-swift";
+				PRODUCT_BUNDLE_IDENTIFIER = "itftwbr.libsignal-protocol-swift";
 				PRODUCT_NAME = SignalProtocol;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -2766,8 +2768,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = H8WR4M6QQ4;
+				DEVELOPMENT_TEAM = RU829Y5CY7;
 				INFOPLIST_FILE = "libsignal-protocol-swiftTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2776,7 +2779,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "christophhagen.libsignal-protocol-swiftTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -2785,8 +2788,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = H8WR4M6QQ4;
+				DEVELOPMENT_TEAM = RU829Y5CY7;
 				INFOPLIST_FILE = "libsignal-protocol-swiftTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2795,7 +2799,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "christophhagen.libsignal-protocol-swiftTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -2804,7 +2808,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
@@ -2839,7 +2843,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;

--- a/libsignal-protocol-swift/Misc/Fingerprint.swift
+++ b/libsignal-protocol-swift/Misc/Fingerprint.swift
@@ -214,6 +214,8 @@ public class Fingerprint {
         guard result == 0 else { throw SignalError(value: result) }
         defer { signal_buffer_free(scannableBuffer) }
 
+        // TODO: I think this is also wrong, but I can't figure out how long
+        // this is supposed to be.  I guess I'll leave it be for now?
         self.displayable = String.init(cString: dPtr)
         self.scannable = Data(signalBuffer: scannableBuffer!)
     }

--- a/libsignal-protocol-swift/Misc/KeyPair.swift
+++ b/libsignal-protocol-swift/Misc/KeyPair.swift
@@ -25,7 +25,7 @@ public struct KeyPair {
      - parameter publicKey: The public key data
      - parameter privateKey: The private key data
      */
-    init(publicKey: Data, privateKey: Data) {
+    public init(publicKey: Data, privateKey: Data) {
         self.publicKey = publicKey
         self.privateKey = privateKey
     }

--- a/libsignal-protocol-swift/Misc/SignalAddress.swift
+++ b/libsignal-protocol-swift/Misc/SignalAddress.swift
@@ -56,7 +56,11 @@ public final class SignalAddress {
         guard let namePtr = address.name else {
             return nil
         }
-        self.init(name: String(cString: namePtr), deviceId: address.device_id)
+        if let name = NSString(bytes: namePtr, length: address.name_len, encoding: String.Encoding.utf8.rawValue) as String? {
+            self.init(name: name, deviceId: address.device_id)
+        } else {
+            self.init(name: String(cString: namePtr), deviceId: address.device_id)
+        }
     }
 
     deinit {

--- a/libsignal-protocol-swift/Misc/SignalSenderKeyName.swift
+++ b/libsignal-protocol-swift/Misc/SignalSenderKeyName.swift
@@ -65,7 +65,11 @@ public final class SignalSenderKeyName {
             let sender = SignalAddress(from: address.sender) else {
             return nil
         }
-        self.init(groupId: String(cString: groupPtr), sender: sender)
+        if let str = NSString(bytes: groupPtr, length: address.group_id_len, encoding: String.Encoding.utf8.rawValue) as String? {
+            self.init(groupId: str, sender: sender)
+        } else {
+            self.init(groupId: String(cString: groupPtr), sender: sender)
+        }
     }
 }
 

--- a/libsignal-protocol-swift/Sessions/SessionBuilder.swift
+++ b/libsignal-protocol-swift/Sessions/SessionBuilder.swift
@@ -52,13 +52,10 @@ public final class SessionBuilder {
         var result = withUnsafeMutablePointer(to: &builder) {
             session_builder_create($0, store.storeContext, remoteAddress.signalAddress, Signal.context)
         }
-        
         guard result == 0 else { throw SignalError(value: result) }
         defer { session_builder_free(builder) }
-
         let bundle = try preKeyBundle.pointer()
         defer { session_pre_key_bundle_destroy(bundle) }
-
         result = session_builder_process_pre_key_bundle(builder, bundle)
         guard result == 0 else { throw SignalError(value: result) }
     }

--- a/libsignal-protocol-swift/Sessions/SessionPreKeyBundle.swift
+++ b/libsignal-protocol-swift/Sessions/SessionPreKeyBundle.swift
@@ -15,28 +15,28 @@ import SignalModule
 public struct SessionPreKeyBundle {
 
     /// The registration id of the remote party
-    let registrationId: UInt32
+    public let registrationId: UInt32
 
     /// The device id of the remote party
-    let deviceId: Int32
+    public let deviceId: Int32
 
     /// The pre key id
-    let preKeyId: UInt32
+    public let preKeyId: UInt32
 
     /// The pre key public data
-    let preKey: Data
+    public let preKey: Data
 
     /// The signed pre key id
-    let signedPreKeyId: UInt32
+    public let signedPreKeyId: UInt32
 
     /// The signed pre key public data
-    let signedPreKey: Data
+    public let signedPreKey: Data
 
     /// The signature of the signed pre key
-    let signature: Data
+    public let signature: Data
 
     /// The identity public key of the remote party
-    let identityKey: Data
+    public let identityKey: Data
 
     /**
      Create a pre key bundle from the components

--- a/libsignal-protocol-swift/StoreWrappers/SessionStoreWrapper.swift
+++ b/libsignal-protocol-swift/StoreWrappers/SessionStoreWrapper.swift
@@ -109,7 +109,12 @@ func getSubDeviceSessions(
         return SignalError.noSignalAddress.rawValue
     }
 
-    let nameString = String(cString: namePtr)
+    let nameString : String
+    if let name = NSString(bytes: namePtr, length: nameLength, encoding: String.Encoding.utf8.rawValue) as String? {
+        nameString = name
+    } else {
+        nameString = String(cString: namePtr)
+    }
 
     guard let results = delegate.subDeviceSessions(for: nameString) else {
         return SignalError.notSuccessful.rawValue
@@ -245,8 +250,13 @@ func deleteAllSessions(
         return SignalError.noSignalAddress.rawValue
     }
 
-    let nameString = String(cString: namePtr)
-
+    let nameString : String
+    if let name = NSString(bytes: namePtr, length: nameLength, encoding: String.Encoding.utf8.rawValue) as String? {
+        nameString = name
+    } else {
+        nameString = String(cString: namePtr)
+    }
+    
     guard let result = delegate.deleteAllSessions(for: nameString) else {
         return SignalError.notSuccessful.rawValue
     }

--- a/libsignal-protocol-swift/libsignal-protocol-c/session_builder.c
+++ b/libsignal-protocol-swift/libsignal-protocol-c/session_builder.c
@@ -209,7 +209,6 @@ int session_builder_process_pre_key_bundle(session_builder *builder, session_pre
     assert(builder->store);
     assert(bundle);
     signal_lock(builder->global_context);
-
     result = signal_protocol_identity_is_trusted_identity(builder->store,
             builder->remote_address,
             session_pre_key_bundle_get_identity_key(bundle));

--- a/libsignal-protocol-swift/libsignal-protocol-c/session_cipher.c
+++ b/libsignal-protocol-swift/libsignal-protocol-c/session_cipher.c
@@ -10,8 +10,6 @@
 #include "protocol.h"
 #include "signal_protocol_internal.h"
 
-#include "stdio.h"
-
 struct session_cipher
 {
     signal_protocol_store_context *store;
@@ -414,7 +412,6 @@ static int session_cipher_decrypt_from_record_and_signal_message(session_cipher 
         SIGNAL_UNREF(state_copy);
     }
 
-
     previous_states_node = session_record_get_previous_states_head(record);
     while(previous_states_node) {
         state = session_record_get_previous_states_element(previous_states_node);
@@ -747,6 +744,7 @@ int session_cipher_get_remote_registration_id(session_cipher *cipher, uint32_t *
     id_result = session_state_get_remote_registration_id(state);
 
 complete:
+    SIGNAL_UNREF(record);
     if(result >= 0) {
         *remote_id = id_result;
     }
@@ -787,6 +785,7 @@ int session_cipher_get_session_version(session_cipher *cipher, uint32_t *version
     version_result = session_state_get_session_version(state);
 
 complete:
+    SIGNAL_UNREF(record);
     if(result >= 0) {
         *version = version_result;
     }

--- a/libsignal-protocol-swiftTests/CipherTests.swift
+++ b/libsignal-protocol-swiftTests/CipherTests.swift
@@ -12,19 +12,27 @@ import SignalProtocol
 class libsignal_protocol_swiftTests: XCTestCase {
 
     func testSetup() {
+//        XCTFail("AHHHHHHHHHHHHH")
 
+        // setup RECP stores
         guard let ownStore = setupStore(makeKeys: true) else {
             XCTFail("Could not create store")
             return
         }
 
-        let ownAddress = SignalAddress(name: "Alice", deviceId: 0)
+        // setup RECP address
+        let ownAddress = SignalAddress(name: "Alice@Alice.AliceAliceAliceAeelice", deviceId: 0)
 
+        // create **RECP PREKEY BUNDLE**
         let bundle: SessionPreKeyBundle
         do {
-            let preKeyData = ownStore.preKeyStore.load(preKey: 1)!
+            // Use prekey "1" for some reason?
+//            let preKeyData = ownStore.preKeyStore.load(preKey: 1)!
+            let preKeyData = ownStore.preKeyStore.load(preKey: 3)!
             let preKey = try SessionPreKey(from: preKeyData)
+            // Use signed prekey "1" also for some reason?
             let signedPreKey = try SessionSignedPreKey(from: ownStore.signedPreKeyStore.load(signedPreKey: 1)!)
+//            let signedPreKey = try SessionSignedPreKey(from: ownStore.signedPreKeyStore.load(signedPreKey: 6)!)
 
             bundle = SessionPreKeyBundle(
                 registrationId: ownStore.identityKeyStore.localRegistrationId()!,
@@ -40,41 +48,55 @@ class libsignal_protocol_swiftTests: XCTestCase {
             return
         }
 
+        // setup SENDER stores
         guard let remoteStore = setupStore(makeKeys: false) else {
             XCTFail("Could not create remote store")
             return
         }
 
         print("Processing bundle...")
+        
+        print("Contains session for address PrePKB: \(remoteStore.sessionStore.containsSession(for: ownAddress))")
 
         do {
+            // MOCK SENDER INITIALIZES SESSION WITH RECP PREKEY BUNDLE
+            print("Buidling session for \(ownAddress.name)")
             try SessionBuilder(for: ownAddress, in: remoteStore).process(preKeyBundle: bundle)
+            print("Done building session")
         } catch {
             XCTFail("Could not process pre key bundle")
             return
         }
+        print("Contains session for address PostPKB: \(remoteStore.sessionStore.containsSession(for: ownAddress))")
+        
+        print("Create cipher...")
+
+        // SENDER creates a cipher for sender w/ their stores
+        let remoteSessionCipher = SessionCipher(for: ownAddress, in: remoteStore)
 
         let message = "Some text".data(using: .utf8)!
 
-        print("Create cipher...")
 
-        let remoteSessionCipher = SessionCipher(for: ownAddress, in: remoteStore)
+        print("Encrypting message1")
 
-        print("Encrypting message...")
-
+        // sender encrypts message
         let encryptedMessage: CiphertextMessage
         do {
             encryptedMessage = try remoteSessionCipher.encrypt(message)
         } catch {
+            print("M1 Encrypt Err: \(error)")
             XCTFail("Could not encrypt message")
             return
         }
-
-        let remoteAddress = SignalAddress(name: "Bob", deviceId: 0)
+        print("Encrypted: \(encryptedMessage.data.base64EncodedString())")
+        
+        // Create Address for Sender
+        let remoteAddress = SignalAddress(name: "+1415246480@asdfasdfa.eeeeeeef", deviceId: 0)
+        // RECP creates a session cipher for SENDER with RECP stores
         let ownSessionCipher = SessionCipher(for: remoteAddress, in: ownStore)
 
-        print("Decrypting message...")
-
+        
+        print("Decrypting message 1")
         let decryptedMessage: Data
         do {
             decryptedMessage = try ownSessionCipher.decrypt(message: encryptedMessage)
@@ -82,7 +104,59 @@ class libsignal_protocol_swiftTests: XCTestCase {
             XCTFail("Could not decrypt message: \(error)")
             return
         }
+        print("Encrypting message2")
+        let m2 = "Message2".data(using: .utf8)!
+        
+        let encryptedM2 : CiphertextMessage
+        do {
+            encryptedM2 = try remoteSessionCipher.encrypt(m2)
+        } catch {
+            XCTFail("Could not encrypt message")
+            return
+        }
+
+        print("Decrypting message 2")
+
+        let decrypted2 : Data
+        do {
+            decrypted2 = try ownSessionCipher.decrypt(message: encryptedM2)
+        } catch {
+            XCTFail("Could not decrypt message: \(error)")
+            return
+        }
+  
+        
+        print("Encrypign message 3")
+        let m3 = "Recp Sending".data(using: .utf8)!
+        let encrypt3 : CiphertextMessage
+        do {
+            encrypt3 = try ownSessionCipher.encrypt(m3)
+        } catch {
+            XCTFail("Could not encrypt message")
+            return
+        }
+        
+        print("Decrypting messgae 3")
+        let decrypt3 : Data
+        do {
+            decrypt3 = try remoteSessionCipher.decrypt(message: encrypt3)
+        } catch {
+            XCTFail("Could not encrypt message")
+            return
+        }
+        
+   
+        print("M1 Type: \(encryptedMessage.type)")
+        print("M2 Type: \(encryptedM2.type)")
+        print("M3 Type: \(encrypt3.type)")
+        
+        print("DecM1: \(String(data: decryptedMessage, encoding: .utf8)!)")
+        print("DecM2: \(String(data: decrypted2, encoding: .utf8)!)")
+        print("DecM3: \(String(data: decrypt3, encoding: .utf8)!)")
 
         XCTAssert(decryptedMessage == message, "Invalid decrypted text")
+        XCTAssert(decrypted2 == m2, "Invalid decrypted text for m2")
+        XCTAssert(decrypt3 == m3, "Invalid decrypted text for m3")
+
     }
 }

--- a/libsignal-protocol-swiftTests/TestHelper.swift
+++ b/libsignal-protocol-swiftTests/TestHelper.swift
@@ -75,6 +75,7 @@ func setupStore(makeKeys: Bool) -> SignalStore? {
 
         // Store signed pre key
         do {
+            print("Sigend PreKeyID: \(signedPreKey.id)")
             (store.signedPreKeyStore as! TestSignedPrekeyStore).keys[signedPreKey.id] = try signedPreKey.data()
         } catch {
             print("Could not serialize signed pre key: \(error)")

--- a/libsignal-protocol-swiftTests/TestImplementation/TestIdentityStore.swift
+++ b/libsignal-protocol-swiftTests/TestImplementation/TestIdentityStore.swift
@@ -26,11 +26,13 @@ class TestIdentityStore: IdentityKeyStore {
     }
 
     func save(identity: Data?, for address: SignalAddress) -> Bool {
+        print("Saving idneitty for \(address.name)")
         keys[address] = identity
         return true
     }
 
     func isTrusted(identity: Data, for address: SignalAddress) -> Bool? {
+        print("Checking Identity for: \(address.name)")
         guard let savedIdentity = keys[address] else {
             return true
         }


### PR DESCRIPTION
Was getting a different key for SignalAddresses every time the tests ran.  Turns out you're doing a bunch of String(cString: ptr) which doesn't work because the address.pointee.name isn't null-terminated.  

Tests were passing just fine because the string it would use for SignalAddress.name was consistent within a test-run, but between test-runs it was inconsistent.  

Fixed that, maybe ruined the test with a bunch of garbage but I'll fix it if you want.  Whatever.   At the very least you should make the changes to all the 'String(cString: ptr)' stuff because it's breaking.

I've integrated the updated lib into my code and it's working beautifully, so pretty confident this works.  