### PR TITLE
Fixed SignalSenderKeyName's constructor groupPointer initialization

### DIFF
--- a/libsignal-protocol-swift/Misc/SignalSenderKeyName.swift
+++ b/libsignal-protocol-swift/Misc/SignalSenderKeyName.swift
@@ -37,7 +37,7 @@ public final class SignalSenderKeyName {
         self.groupId = groupId
         self.sender = sender
         let count = groupId.utf8.count
-        self.groupPointer = UnsafeMutablePointer<Int8>.allocate(capacity: count)
+        self.groupPointer = UnsafeMutablePointer<Int8>(mutating: (groupId as NSString).utf8String!)
         groupPointer.assign(from: groupId, count: count)
         self.address = UnsafeMutablePointer<signal_protocol_sender_key_name>.allocate(capacity: 1)
 


### PR DESCRIPTION
Same problem seen here https://github.com/christophhagen/libsignal-protocol-swift/issues/2 was existing for `SignalSenderKeyName`