### PR TITLE
Fixed CocoaPods integration, Fixed SignalSenderKeyName, updated deprecated use of hasher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
+# Mac OS X
+*.DS_Store
 
 build
+xcuserdata/

--- a/libsignal-protocol-swift.podspec
+++ b/libsignal-protocol-swift.podspec
@@ -24,9 +24,9 @@ Pod::Spec.new do |spec|
     spec.private_header_files = 'libsignal-protocol-swift/**/*.h'
 
     spec.pod_target_xcconfig = { 
-    	'SWIFT_INCLUDE_PATHS' => '${BUILT_PRODUCTS_DIR}/SignalModuleMap, ${BUILT_PRODUCTS_DIR}/CommonCryptoModuleMap'
+    	'SWIFT_INCLUDE_PATHS' => '${SRCROOT}/libsignal-protocol-swift/**',
+      'HEADER_SEARCH_PATHS' => '${SRCROOT}/libsignal-protocol-swift/libsignal-protocol-c/** ${SRCROOT}/libsignal-protocol-swift/libsignal-protocol-swift/libsignal-protocol-c/**',
     }
-    spec.resources = '$(BUILT_PRODUCTS_DIR)/**/*.modulemap'
-    spec.preserve_paths = '$(BUILT_PRODUCTS_DIR)/**/*.modulemap'
+    spec.preserve_paths = 'libsignal-protocol-swift/module.modulemap'
     
 end

--- a/libsignal-protocol-swift.xcodeproj/project.pbxproj
+++ b/libsignal-protocol-swift.xcodeproj/project.pbxproj
@@ -6,20 +6,6 @@
 	objectVersion = 50;
 	objects = {
 
-/* Begin PBXAggregateTarget section */
-		CE1F0FC120347C84003F1C04 /* SignalModuleMap */ = {
-			isa = PBXAggregateTarget;
-			buildConfigurationList = CE1F0FC220347C84003F1C04 /* Build configuration list for PBXAggregateTarget "SignalModuleMap" */;
-			buildPhases = (
-				CE1F0FC520347C90003F1C04 /* ShellScript */,
-			);
-			dependencies = (
-			);
-			name = SignalModuleMap;
-			productName = SignalModuleMap;
-		};
-/* End PBXAggregateTarget section */
-
 /* Begin PBXBuildFile section */
 		CE048C342036F890002AB31C /* SignalError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE048C332036F890002AB31C /* SignalError.swift */; };
 		CE048C352036F890002AB31C /* SignalError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE048C332036F890002AB31C /* SignalError.swift */; };
@@ -825,37 +811,12 @@
 			remoteGlobalIDString = CE1F0C34203467B3003F1C04;
 			remoteInfo = "libsignal-protocol-swift";
 		};
-		CE1F0FC620347DB5003F1C04 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = CE1F0C2C203467B3003F1C04 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = CE1F0FC120347C84003F1C04;
-			remoteInfo = SignalModuleMap;
-		};
-		CE8523932034804C0086B02D /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = CE1F0C2C203467B3003F1C04 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = CE1F0FC120347C84003F1C04;
-			remoteInfo = SignalModuleMap;
-		};
-		CE852395203480500086B02D /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = CE1F0C2C203467B3003F1C04 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = CE1F0FC120347C84003F1C04;
-			remoteInfo = SignalModuleMap;
-		};
-		CE852397203480540086B02D /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = CE1F0C2C203467B3003F1C04 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = CE1F0FC120347C84003F1C04;
-			remoteInfo = SignalModuleMap;
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		A060453525ED4AF10063391D /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
+		A060458525ED4D760063391D /* SignalProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalProtocolTests.swift; sourceTree = "<group>"; };
+		A060458725ED4D760063391D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CE048C332036F890002AB31C /* SignalError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalError.swift; sourceTree = "<group>"; };
 		CE1933552036F17500C71032 /* CiphertextMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CiphertextMessage.swift; sourceTree = "<group>"; };
 		CE1F0C35203467B3003F1C04 /* SignalProtocol.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SignalProtocol.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1110,11 +1071,21 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		A060458425ED4D760063391D /* SignalProtocolTests */ = {
+			isa = PBXGroup;
+			children = (
+				A060458525ED4D760063391D /* SignalProtocolTests.swift */,
+				A060458725ED4D760063391D /* Info.plist */,
+			);
+			path = SignalProtocolTests;
+			sourceTree = "<group>";
+		};
 		CE1F0C2B203467B3003F1C04 = {
 			isa = PBXGroup;
 			children = (
 				CE1F0C37203467B3003F1C04 /* libsignal-protocol-swift */,
 				CE1F0C42203467B3003F1C04 /* libsignal-protocol-swiftTests */,
+				A060458425ED4D760063391D /* SignalProtocolTests */,
 				CE1F0C36203467B3003F1C04 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -1134,6 +1105,7 @@
 		CE1F0C37203467B3003F1C04 /* libsignal-protocol-swift */ = {
 			isa = PBXGroup;
 			children = (
+				A060453525ED4AF10063391D /* module.modulemap */,
 				CE1F0C76203468B8003F1C04 /* Additional */,
 				CE1F0C772034696C003F1C04 /* libsignal-protocol-c */,
 				CEE3453420351369001FE63B /* Misc */,
@@ -1810,7 +1782,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				CE1F0FC720347DB5003F1C04 /* PBXTargetDependency */,
 			);
 			name = "libsignal-protocol-swift iOS";
 			productName = "libsignal-protocol-swift";
@@ -1847,7 +1818,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				CE8523942034804C0086B02D /* PBXTargetDependency */,
 			);
 			name = "libsignal-protocol-swift macOS";
 			productName = "libsignal-protocol-swift";
@@ -1866,7 +1836,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				CE852396203480500086B02D /* PBXTargetDependency */,
 			);
 			name = "libsignal-protocol-swift tvOS";
 			productName = "libsignal-protocol-swift";
@@ -1885,7 +1854,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				CE852398203480540086B02D /* PBXTargetDependency */,
 			);
 			name = "libsignal-protocol-swift watchOS";
 			productName = "libsignal-protocol-swift";
@@ -1898,7 +1866,7 @@
 		CE1F0C2C203467B3003F1C04 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0930;
+				LastSwiftUpdateCheck = 1220;
 				LastUpgradeCheck = 0930;
 				ORGANIZATIONNAME = User;
 				TargetAttributes = {
@@ -1921,9 +1889,6 @@
 						CreatedOnToolsVersion = 9.3;
 						LastSwiftMigration = 0930;
 					};
-					CE1F0FC120347C84003F1C04 = {
-						CreatedOnToolsVersion = 9.3;
-					};
 				};
 			};
 			buildConfigurationList = CE1F0C2F203467B3003F1C04 /* Build configuration list for PBXProject "libsignal-protocol-swift" */;
@@ -1943,7 +1908,6 @@
 				CE1F0C602034685B003F1C04 /* libsignal-protocol-swift tvOS */,
 				CE1F0C6D20346875003F1C04 /* libsignal-protocol-swift watchOS */,
 				CE1F0C3D203467B3003F1C04 /* libsignal-protocol-swiftTests */,
-				CE1F0FC120347C84003F1C04 /* SignalModuleMap */,
 			);
 		};
 /* End PBXProject section */
@@ -1985,22 +1949,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		CE1F0FC520347C90003F1C04 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# This if-statement means we'll only run the main script if the SignalModuleMap directory doesn't exist\n# Because otherwise the rest of the script causes a full recompile for anything where SignalProtocol is a dependency\n# Do a \"Clean Build Folder\" to remove this directory and trigger the rest of the script to run\nif [ -d \"${BUILT_PRODUCTS_DIR}/SignalModuleMap\" ]; then\necho \"${BUILT_PRODUCTS_DIR}/SignalModuleMap directory already exists, not creating module map.\"\nelse\n\nmkdir -p \"${BUILT_PRODUCTS_DIR}/SignalModuleMap\"\ncat <<EOF > \"${BUILT_PRODUCTS_DIR}/SignalModuleMap/module.modulemap\"\nmodule SignalModule [system] {\nheader \"${SRCROOT}/libsignal-protocol-swift/libsignal-protocol-c/signal_protocol.h\"\nheader \"${SRCROOT}/libsignal-protocol-swift/libsignal-protocol-c/key_helper.h\"\nheader \"${SRCROOT}/libsignal-protocol-swift/libsignal-protocol-c/session_builder.h\"\nheader \"${SRCROOT}/libsignal-protocol-swift/libsignal-protocol-c/session_cipher.h\"\nheader \"${SRCROOT}/libsignal-protocol-swift/libsignal-protocol-c/protocol.h\"\nheader \"${SRCROOT}/libsignal-protocol-swift/libsignal-protocol-c/group_session_builder.h\"\nheader \"${SRCROOT}/libsignal-protocol-swift/libsignal-protocol-c/group_cipher.h\"\nheader \"${SRCROOT}/libsignal-protocol-swift/libsignal-protocol-c/fingerprint.h\"\nexport *\n}\nEOF\nfi\n\nCOMMON_CRYPTO_DIR=\"${SDKROOT}/usr/include/CommonCrypto\"\nif [ -f \"${COMMON_CRYPTO_DIR}/module.modulemap\" ]; then :; fi\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		CE1F0C30203467B3003F1C04 /* Sources */ = {
@@ -2555,26 +2503,6 @@
 			target = CE1F0C34203467B3003F1C04 /* libsignal-protocol-swift iOS */;
 			targetProxy = CE1F0C40203467B3003F1C04 /* PBXContainerItemProxy */;
 		};
-		CE1F0FC720347DB5003F1C04 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = CE1F0FC120347C84003F1C04 /* SignalModuleMap */;
-			targetProxy = CE1F0FC620347DB5003F1C04 /* PBXContainerItemProxy */;
-		};
-		CE8523942034804C0086B02D /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = CE1F0FC120347C84003F1C04 /* SignalModuleMap */;
-			targetProxy = CE8523932034804C0086B02D /* PBXContainerItemProxy */;
-		};
-		CE852396203480500086B02D /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = CE1F0FC120347C84003F1C04 /* SignalModuleMap */;
-			targetProxy = CE852395203480500086B02D /* PBXContainerItemProxy */;
-		};
-		CE852398203480540086B02D /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = CE1F0FC120347C84003F1C04 /* SignalModuleMap */;
-			targetProxy = CE852397203480540086B02D /* PBXContainerItemProxy */;
-		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
@@ -2631,10 +2559,12 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
+				MODULEMAP_FILE = "libsignal-protocol-swift/module.modulemap";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INCLUDE_PATHS = "${SRCROOT}/libsignal-protocol-swift/**";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.2;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -2689,8 +2619,10 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
+				MODULEMAP_FILE = "libsignal-protocol-swift/module.modulemap";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_INCLUDE_PATHS = "${SRCROOT}/libsignal-protocol-swift/**";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 4.2;
 				VALIDATE_PRODUCT = YES;
@@ -2710,11 +2642,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				HEADER_SEARCH_PATHS = (
-					"${SRCROOT}/libsignal-protocol-swift/libsignal-protocol-c/**",
-					"${BUILT_PRODUCTS_DIR}/SignalModuleMap",
-					"${BUILT_PRODUCTS_DIR}/CommonCryptoModuleMap",
-				);
+				HEADER_SEARCH_PATHS = "${SRCROOT}/libsignal-protocol-swift/libsignal-protocol-c/**";
 				INFOPLIST_FILE = "$(SRCROOT)/libsignal-protocol-swift/Additional/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2722,6 +2650,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MODULEMAP_FILE = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "christophhagen.libsignal-protocol-swift";
 				PRODUCT_NAME = SignalProtocol;
 				SKIP_INSTALL = YES;
@@ -2742,11 +2671,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				HEADER_SEARCH_PATHS = (
-					"${SRCROOT}/libsignal-protocol-swift/libsignal-protocol-c/**",
-					"${BUILT_PRODUCTS_DIR}/SignalModuleMap",
-					"${BUILT_PRODUCTS_DIR}/CommonCryptoModuleMap",
-				);
+				HEADER_SEARCH_PATHS = "${SRCROOT}/libsignal-protocol-swift/libsignal-protocol-c/**";
 				INFOPLIST_FILE = "$(SRCROOT)/libsignal-protocol-swift/Additional/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2754,6 +2679,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MODULEMAP_FILE = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "christophhagen.libsignal-protocol-swift";
 				PRODUCT_NAME = SignalProtocol;
 				SKIP_INSTALL = YES;
@@ -3005,30 +2931,6 @@
 			};
 			name = Release;
 		};
-		CE1F0FC320347C84003F1C04 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = H8WR4M6QQ4;
-				HEADER_SEARCH_PATHS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvos appletvsimulator watchos watchsimulator";
-				VALID_ARCHS = "arm64 armv7 armv7s armv7k i386 x86_64";
-			};
-			name = Debug;
-		};
-		CE1F0FC420347C84003F1C04 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = H8WR4M6QQ4;
-				HEADER_SEARCH_PATHS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvos appletvsimulator watchos watchsimulator";
-				VALID_ARCHS = "arm64 armv7 armv7s armv7k i386 x86_64";
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -3082,15 +2984,6 @@
 			buildConfigurations = (
 				CE1F0C7420346875003F1C04 /* Debug */,
 				CE1F0C7520346875003F1C04 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		CE1F0FC220347C84003F1C04 /* Build configuration list for PBXAggregateTarget "SignalModuleMap" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				CE1F0FC320347C84003F1C04 /* Debug */,
-				CE1F0FC420347C84003F1C04 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/libsignal-protocol-swift/Misc/SignalAddress.swift
+++ b/libsignal-protocol-swift/Misc/SignalAddress.swift
@@ -83,5 +83,9 @@ extension SignalAddress: Hashable {
     public var hashValue: Int {
         return name.hashValue &+ deviceId.hashValue
     }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(name)
+        hasher.combine(deviceId)
+    }
 }
 

--- a/libsignal-protocol-swift/Misc/SignalSenderKeyName.swift
+++ b/libsignal-protocol-swift/Misc/SignalSenderKeyName.swift
@@ -37,7 +37,7 @@ public final class SignalSenderKeyName {
         self.groupId = groupId
         self.sender = sender
         let count = groupId.utf8.count
-        self.groupPointer = UnsafeMutablePointer<Int8>.allocate(capacity: count)
+        self.groupPointer = UnsafeMutablePointer<Int8>(mutating: (groupId as NSString).utf8String!)
         groupPointer.assign(from: groupId, count: count)
         self.address = UnsafeMutablePointer<signal_protocol_sender_key_name>.allocate(capacity: 1)
 
@@ -86,8 +86,9 @@ extension SignalSenderKeyName: Equatable {
 extension SignalSenderKeyName: Hashable {
 
     /// The hash of the sender key name
-    public var hashValue: Int {
-        return groupId.hashValue &+ sender.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(groupId)
+        hasher.combine(sender)
     }
 
 }

--- a/libsignal-protocol-swift/Setup/Signal.swift
+++ b/libsignal-protocol-swift/Setup/Signal.swift
@@ -46,7 +46,7 @@ public extension Signal {
     static func generateIdentityKeyPair() throws -> KeyPair {
         // Create key pair
         var keyPair: OpaquePointer? = nil
-        var result = withUnsafeMutablePointer(to: &keyPair) {
+        let result = withUnsafeMutablePointer(to: &keyPair) {
             signal_protocol_key_helper_generate_identity_key_pair($0, Signal.context)
         }
         guard result == 0 else { throw SignalError(value: result) }
@@ -122,7 +122,7 @@ public extension Signal {
         let pointer = try identity.pointer()
         defer { ec_key_pair_destroy(pointer) }
         var keyPtr: OpaquePointer? = nil
-        var result = withUnsafeMutablePointer(to: &keyPtr) {
+        let result = withUnsafeMutablePointer(to: &keyPtr) {
             signal_protocol_key_helper_generate_signed_pre_key($0, pointer, signedPreKey, timestamp, Signal.context)
         }
         guard result == 0 else { throw SignalError(value: result) }

--- a/libsignal-protocol-swift/module.modulemap
+++ b/libsignal-protocol-swift/module.modulemap
@@ -1,0 +1,14 @@
+module SignalModule [system] {
+    header "SignalProtocol.h"
+    header "Setup/setup.h"
+    header "libsignal-protocol-c/signal_protocol.h"
+    header "libsignal-protocol-c/signal_protocol.h"
+    header "libsignal-protocol-c/key_helper.h"
+    header "libsignal-protocol-c/session_builder.h"
+    header "libsignal-protocol-c/session_cipher.h"
+    header "libsignal-protocol-c/protocol.h"
+    header "libsignal-protocol-c/group_session_builder.h"
+    header "libsignal-protocol-c/group_cipher.h"
+    header "libsignal-protocol-c/fingerprint.h"
+    export *
+}


### PR DESCRIPTION
**Cocoapods**
- Moved from dynamic modulemap to a static one (CommonCrypto import was unuseful)
- Wrapping top-level C headers into modulemap to expose them
- Updated Podspec
As a result, libsignal-protocol-swift is now embeddable from cocoapods by using either a Development Pod or a remote pod

`pod 'libsignal-protocol-swift', :git => 'https://github.com/thibauddavid/libsignal-protocol-swift', :branch => 'fixedCocoapodImport'`
`pod 'libsignal-protocol-swift', :path => '../libs/libsignal-protocol-swift-master'`

**SignalSenderKeyName**
Was using a broken init, same problem as SignalAddress as referenced here https://github.com/christophhagen/libsignal-protocol-swift/issues/2

**Hashing**
Was still using deprecated `hashValue `, which I replaced by using `func hash(into hasher: inout Hasher)`
